### PR TITLE
Use new inline scan container

### DIFF
--- a/cmd/harbor-scanner-sysdig-secure/main.go
+++ b/cmd/harbor-scanner-sysdig-secure/main.go
@@ -46,7 +46,6 @@ func configure() error {
 	pflag.Bool("verify_ssl", true, "Verify SSL when connecting to Sysdig Secure URL Endpoint")
 	pflag.Bool("inline_scanning", false, "Use Inline Scanning Adapter")
 	pflag.String("namespace_name", "", "Namespace where inline scanning jobs are spawned")
-	pflag.String("configmap_name", "", "Configmap which keeps the inline scanning settings")
 	pflag.String("secret_name", "", "Secret which keeps the inline scanning secrets ")
 
 	pflag.VisitAll(func(flag *pflag.Flag) { viper.BindPFlag(flag.Name, flag) })
@@ -57,8 +56,8 @@ func configure() error {
 		return errors.New("secure_api_token is required")
 	}
 
-	if viper.GetBool("inline_scanning") && (viper.Get("namespace_name") == "" || viper.Get("configmap_name") == "" || viper.Get("secret_name") == "") {
-		return errors.New("namespace_name, configmap_name and secret_name are required when running inline scanning")
+	if viper.GetBool("inline_scanning") && (viper.Get("namespace_name") == "" || viper.Get("secret_name") == "") {
+		return errors.New("namespace_name and secret_name are required when running inline scanning")
 	}
 
 	return nil
@@ -83,7 +82,6 @@ func getAdapter() scanner.Adapter {
 			clientset,
 			viper.GetString("secure_url"),
 			viper.GetString("namespace_name"),
-			viper.GetString("configmap_name"),
 			viper.GetString("secret_name"))
 	}
 

--- a/pkg/scanner/inline_adapter.go
+++ b/pkg/scanner/inline_adapter.go
@@ -21,18 +21,16 @@ type inlineAdapter struct {
 	k8sClient kubernetes.Interface
 	secureURL string
 	namespace string
-	configMap string
 	secret    string
 	jobTTL    int32
 }
 
-func NewInlineAdapter(secureClient secure.Client, k8sClient kubernetes.Interface, secureURL string, namespace string, configMap string, secret string) Adapter {
+func NewInlineAdapter(secureClient secure.Client, k8sClient kubernetes.Interface, secureURL string, namespace string, secret string) Adapter {
 	return &inlineAdapter{
 		BaseAdapter: BaseAdapter{secureClient: secureClient},
 		k8sClient:   k8sClient,
 		secureURL:   secureURL,
 		namespace:   namespace,
-		configMap:   configMap,
 		secret:      secret,
 		jobTTL:      int32(24 * time.Hour.Seconds()),
 	}

--- a/pkg/scanner/inline_adapter.go
+++ b/pkg/scanner/inline_adapter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/md5"
 	"fmt"
-	"net/url"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -64,7 +63,8 @@ func (i *inlineAdapter) createJobFrom(req harbor.ScanRequest) error {
 
 func (i *inlineAdapter) buildJob(req harbor.ScanRequest) *batchv1.Job {
 	name := jobName(req.Artifact.Repository, req.Artifact.Digest)
-	repositoryURL, _ := url.Parse(req.Registry.URL)
+	user, password := getUserAndPasswordFrom(req.Registry.Authorization)
+	userPassword := fmt.Sprintf("%s:%s", user, password)
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -75,36 +75,22 @@ func (i *inlineAdapter) buildJob(req harbor.ScanRequest) *batchv1.Job {
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					RestartPolicy: "OnFailure",
-					InitContainers: []corev1.Container{
-						{
-							Name:  "harbor-certificate-dumper",
-							Image: "busybox",
-							Command: []string{
-								"sh",
-								"-c",
-								fmt.Sprintf("mkdir -p /etc/docker/certs.d/%s && cp /tmp/ca.crt /etc/docker/certs.d/%s", repositoryURL.Host, repositoryURL.Host),
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "docker-certificates",
-									MountPath: "/etc/docker/certs.d",
-									ReadOnly:  false,
-								},
-								{
-									Name:      "certificate",
-									MountPath: "/tmp",
-								},
-							},
-						},
-					},
 					Containers: []corev1.Container{
 						{
-							Name:    "scanner",
-							Image:   "sysdiglabs/secure-inline-scan",
-							Command: []string{"/bin/bash"},
+							Name:  "scanner",
+							Image: "sysdiglabs/sysdig-inline-scan:harbor-1.0",
 							Args: []string{
-								"-c",
-								fmt.Sprintf("docker login %s -u '$(HARBOR_ROBOTACCOUNT_USER)' -p '$(HARBOR_ROBOTACCOUNT_PASSWORD)' && (/bin/inline_scan.sh analyze -s '%s' -k '$(SYSDIG_SECURE_API_TOKEN)' -d '%s' -P %s || true )", repositoryURL.Host, i.secureURL, req.Artifact.Digest, getImageFrom(req)),
+								"-s",
+								i.secureURL,
+								"-k",
+								"$(SYSDIG_SECURE_API_TOKEN)",
+								"-d",
+								req.Artifact.Digest,
+								"-P",
+								"-n",
+								"-u",
+								userPassword,
+								getImageFrom(req),
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -115,68 +101,6 @@ func (i *inlineAdapter) buildJob(req harbor.ScanRequest) *batchv1.Job {
 												Name: i.secret,
 											},
 											Key: "sysdig_secure_api_token",
-										},
-									},
-								},
-								{
-									Name: "HARBOR_ROBOTACCOUNT_USER",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: i.secret,
-											},
-											Key: "harbor_robot_account_name",
-										},
-									},
-								},
-								{
-									Name: "HARBOR_ROBOTACCOUNT_PASSWORD",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: i.secret,
-											},
-											Key: "harbor_robot_account_password",
-										},
-									},
-								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "docker-daemon",
-									MountPath: "/var/run/docker.sock",
-								},
-							},
-						},
-					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "docker-daemon",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/var/run/docker.sock",
-								},
-							},
-						},
-						{
-							Name: "docker-certificates",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/etc/docker/certs.d",
-								},
-							},
-						},
-						{
-							Name: "certificate",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: i.configMap,
-									},
-									Items: []corev1.KeyToPath{
-										{
-											Key:  "harbor_ca",
-											Path: "ca.crt",
 										},
 									},
 								},

--- a/pkg/scanner/inline_adapter_test.go
+++ b/pkg/scanner/inline_adapter_test.go
@@ -147,36 +147,22 @@ func job() *batchv1.Job {
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					RestartPolicy: "OnFailure",
-					InitContainers: []corev1.Container{
-						{
-							Name:  "harbor-certificate-dumper",
-							Image: "busybox",
-							Command: []string{
-								"sh",
-								"-c",
-								"mkdir -p /etc/docker/certs.d/harbor.sysdig-demo.zone && cp /tmp/ca.crt /etc/docker/certs.d/harbor.sysdig-demo.zone",
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "docker-certificates",
-									MountPath: "/etc/docker/certs.d",
-									ReadOnly:  false,
-								},
-								{
-									Name:      "certificate",
-									MountPath: "/tmp",
-								},
-							},
-						},
-					},
 					Containers: []corev1.Container{
 						{
-							Name:    "scanner",
-							Image:   "sysdiglabs/secure-inline-scan",
-							Command: []string{"/bin/bash"},
+							Name:  "scanner",
+							Image: "sysdiglabs/sysdig-inline-scan:harbor-1.0",
 							Args: []string{
-								"-c",
-								"docker login harbor.sysdig-demo.zone -u '$(HARBOR_ROBOTACCOUNT_USER)' -p '$(HARBOR_ROBOTACCOUNT_PASSWORD)' && (/bin/inline_scan.sh analyze -s 'https://secure.sysdig.com' -k '$(SYSDIG_SECURE_API_TOKEN)' -d 'an image digest' -P harbor.sysdig-demo.zone/sysdig/agent:9.7.0 || true )",
+								"-s",
+								"https://secure.sysdig.com",
+								"-k",
+								"$(SYSDIG_SECURE_API_TOKEN)",
+								"-d",
+								"an image digest",
+								"-P",
+								"-n",
+								"-u",
+								"robot$9f6711d1-834d-11ea-867f-76103d08dca8:eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1OTAwMDk5OTksImlhdCI6MTU4NzQxNzk5OSwiaXNzIjoiaGFyYm9yLXRva2VuLWRlZmF1bHRJc3N1ZXIiLCJpZCI6OSwicGlkIjoyLCJhY2Nlc3MiOlt7IlJlc291cmNlIjoiL3Byb2plY3QvMi9yZXBvc2l0b3J5IiwiQWN0aW9uIjoic2Nhbm5lci1wdWxsIiwiRWZmZWN0IjoiIn1dfQ.A3_aTzvxqSTvl26pQKa97ay15zRPC9K55NE0WbEyOsY3m0KFz-HuSDatncWLSYvOlcGVdysKlF3JXYWIjQ7tEI4V76WA9UMoi-fr9vEEdWLF5C1uWZJOz_S72sQ3G1BzsLp3HyWe9ZN5EBK9mhXzYNv2rONYrr0UJeBmNnMf2mU3sH71OO_G6JvRl5fwFSLSYx8nQs82PhfVhx50wRuWl_zyeCCDy_ytLzjRBvZwKuI9iVIxgM1pRfKG15NWMHfl0lcYnjm7f1_WFGKtVddkLOTICK0_FPtef1L8A16ozo_2NA32WD9PstdcTuD37XbZ6AFXUAZFoZLfCEW97mtIZBY2uYMwDQtc6Nme4o3Ya-MnBEIAs9Vi9d5a4pkf7Two-xjI-9ESgVz79YqL-_OnecQPNJ9yAFtJuxQ7StfsCIZx84hh5VdcZmW9jlezRHh4hTAjsNmrOBFTAjPyaXk98Se3Fj0Ev3bChod63og4frE7_fE7HnoBKVPHRAdBhJ2yrAiPymfij_kD4ke1Vb0AxmGGOwRP2K3TZNqEdKcq89lU6lHYV2UfrWchuF3u4ieNEC1BGu1_m_c55f0YZH1FAq6evCyA0JnFuXzO4cCxC7WHzXXRGSC9Lm3LF7cbaZAgFj5d34gbgUQmJst8nPlpW-KtwRL-pHC6mipunCBv9bU",
+								"harbor.sysdig-demo.zone/sysdig/agent:9.7.0",
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -187,68 +173,6 @@ func job() *batchv1.Job {
 												Name: secret,
 											},
 											Key: "sysdig_secure_api_token",
-										},
-									},
-								},
-								{
-									Name: "HARBOR_ROBOTACCOUNT_USER",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: secret,
-											},
-											Key: "harbor_robot_account_name",
-										},
-									},
-								},
-								{
-									Name: "HARBOR_ROBOTACCOUNT_PASSWORD",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: secret,
-											},
-											Key: "harbor_robot_account_password",
-										},
-									},
-								},
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "docker-daemon",
-									MountPath: "/var/run/docker.sock",
-								},
-							},
-						},
-					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "docker-daemon",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/var/run/docker.sock",
-								},
-							},
-						},
-						{
-							Name: "docker-certificates",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/etc/docker/certs.d",
-								},
-							},
-						},
-						{
-							Name: "certificate",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: configMap,
-									},
-									Items: []corev1.KeyToPath{
-										{
-											Key:  "harbor_ca",
-											Path: "ca.crt",
 										},
 									},
 								},

--- a/pkg/scanner/inline_adapter_test.go
+++ b/pkg/scanner/inline_adapter_test.go
@@ -27,7 +27,6 @@ import (
 const (
 	secureURL    = "https://secure.sysdig.com"
 	namespace    = "a-namespace"
-	configMap    = "a-configmap"
 	secret       = "a-secret"
 	resourceName = "inline-scan-1e668f7cc4c27e915cfed9793808357e"
 )
@@ -44,7 +43,7 @@ var _ = Describe("InlineAdapter", func() {
 		controller = gomock.NewController(GinkgoT())
 		client = mocks.NewMockClient(controller)
 		k8sClient = fake.NewSimpleClientset()
-		inlineAdapter = scanner.NewInlineAdapter(client, k8sClient, secureURL, namespace, configMap, secret)
+		inlineAdapter = scanner.NewInlineAdapter(client, k8sClient, secureURL, namespace, secret)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Use new inline-scan container to perform the inline scanning, using the temporary credentials provided in the request to the scan adapter.