### PR TITLE
Initial CLI scanner commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ This adapter also provides a service that translates the Harbor scanning API req
 
 You can follow a [detailed guide to deploy the Scanner Adapter](docs/install.md).
 
-## Inline and Backend Scanning
+## CLI and Backend Scanning
 
 This scanning adapter has two operation modes:
 * Backend Scanning: Image scanning happens in the Sysdig Secure Backend
-* Inline Scanning: Image scanning happens in the infrastructure where Harbor is hosted
+* CLI Scanning: Image scanning happens in the infrastructure where Harbor is hosted
 
 ### Backend Scanning
 
@@ -28,9 +28,9 @@ PRO:
 CON:
 * Sysdig Secure Backend needs to have network visibility in order to fetch images from Harbor
 
-### Inline Scanning
+### CLI Scanning
 
-Using inline scanning, the scanning operation itself will be triggered and performed on your own infrastructure. It spawns a Kubernetes job when a new image is pushed, this job will communicate **only** the container metadata to the Sysdig Secure Backend, which will perform the evaluation based on the configured image [scanning policies](https://docs.sysdig.com/en/manage-scanning-policies.html).
+Using CLI scanning, the scanning operation itself will be triggered and performed on your own infrastructure. It spawns a Kubernetes job when a new image is pushed, this job will communicate **only** the container metadata to the Sysdig Secure Backend, which will perform the evaluation based on the configured image [scanning policies](https://docs.sysdig.com/en/manage-scanning-policies.html).
 
 PRO:
 * No need to configure registry credentials in the Sysdig Secure Backend
@@ -38,17 +38,17 @@ PRO:
 * Image contents are never transmitted outside the pipeline, just the image metadata
 
 CON:
-* The job performing the inline scanning needs to have access to the host-local Docker daemon
+* The job performing the CLI scanning needs to have access to the host-local Docker daemon
 
 ## Configuration
 
 Configuration of the adapter is done via environment variables at startup.
 
-| Name               | Default | Description                                                               |
-| ---                | ---     | ---                                                                       |
-| `SECURE_URL`       | ` `     | Sysdig Secure URL                                                         |
+| Name              | Default | Description                                                               |
+|-------------------| ---     | ---                                                                       |
+| `SECURE_URL`      | ` `     | Sysdig Secure URL                                                         |
 | `SECURE_API_TOKEN` | ` `     | Sysdig Secure API Token                                                   |
-| `INLINE_SCANNING`  | ` `     | Enable Inline Scanning instead of Backend                                 |
-| `NAMESPACE_NAME`   | ` `     | Namespace where Inline Scanning will spawn jobs                           |
-| `CONFIGMAP_NAME`   | ` `     | ConfigMap name where Harbor Certificate is available                      |
-| `SECRET_NAME`      | ` `     | Secret name where Sysdig Secure API Token and Robot Account are available |
+| `CLI_SCANNING`    | ` `     | Enable CLI Scanning instead of Backend                                 |
+| `NAMESPACE_NAME`  | ` `     | Namespace where CLI Scanning will spawn jobs                           |
+| `CONFIGMAP_NAME`  | ` `     | ConfigMap name where Harbor Certificate is available                      |
+| `SECRET_NAME`     | ` `     | Secret name where Sysdig Secure API Token and Robot Account are available |

--- a/cmd/harbor-scanner-sysdig-secure/main.go
+++ b/cmd/harbor-scanner-sysdig-secure/main.go
@@ -53,11 +53,11 @@ func configure() error {
 	pflag.String("secure_api_token", "", "Sysdig Secure API Token")
 	pflag.String("secure_url", "https://secure.sysdig.com", "Sysdig Secure URL Endpoint")
 	pflag.Bool("verify_ssl", true, "Verify SSL when connecting to Sysdig Secure URL Endpoint")
-	pflag.Bool("inline_scanning", false, "Use Inline Scanning Adapter")
+	pflag.Bool("cli_scanning", false, "Use Sysdig-Cli-Scanner Scanning Adapter")
 	pflag.Bool("async_mode", false, "Use Async-Mode to perform reports retrieval")
 	pflag.String("namespace_name", "", "Namespace where inline scanning jobs are spawned")
 	pflag.String("secret_name", "", "Secret which keeps the inline scanning secrets ")
-	pflag.String("inline_scanning_extra_params", "", "Extra parameters to provide to inline-scanner")
+	pflag.String("cli_scanning_extra_params", "", "Extra parameters to provide to cli-scanner")
 
 	pflag.VisitAll(func(flag *pflag.Flag) { viper.BindPFlag(flag.Name, flag) })
 
@@ -67,8 +67,8 @@ func configure() error {
 		return errors.New("secure_api_token is required")
 	}
 
-	if viper.GetBool("inline_scanning") && (viper.Get("namespace_name") == "" || viper.Get("secret_name") == "") {
-		return errors.New("namespace_name and secret_name are required when running inline scanning")
+	if viper.GetBool("cli_scanning") && (viper.Get("namespace_name") == "" || viper.Get("secret_name") == "") {
+		return errors.New("namespace_name and secret_name are required when running sysdig-cli-scanner")
 	}
 
 	return nil
@@ -77,8 +77,8 @@ func configure() error {
 func getAdapter() scanner.Adapter {
 	client := secure.NewClient(viper.GetString("secure_api_token"), viper.GetString("secure_url"), viper.GetBool("verify_ssl"))
 
-	if viper.GetBool("inline_scanning") {
-		log.Info("Using inline-scanning adapter")
+	if viper.GetBool("cli_scanning") {
+		log.Info("Using cli-scanner adapter")
 		config, err := rest.InClusterConfig()
 		if err != nil {
 			log.Fatal(err)
@@ -95,7 +95,7 @@ func getAdapter() scanner.Adapter {
 			viper.GetString("secure_url"),
 			viper.GetString("namespace_name"),
 			viper.GetString("secret_name"),
-			viper.GetString("inline_scanning_extra_params"),
+			viper.GetString("cli_scanning_extra_params"),
 			viper.GetBool("verify_ssl"),
 			log.StandardLogger())
 	}

--- a/pkg/harbor/model.go
+++ b/pkg/harbor/model.go
@@ -7,7 +7,7 @@ const (
 	OCIImageManifestMimeType           = "application/vnd.oci.image.manifest.v1+json"
 	DockerDistributionManifestMimeType = "application/vnd.docker.distribution.manifest.v2+json"
 	ScanResponseMimeType               = "application/vnd.scanner.adapter.scan.response+json; version=1.0"
-	ScanReportMimeType                 = "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0"
+	ScanReportMimeType                 = "application/vnd.security.vulnerability.report; version=1.1"
 	ScanAdapterErrorMimeType           = "application/vnd.scanner.adapter.error+json; version=1.0"
 )
 
@@ -78,11 +78,28 @@ const (
 )
 
 type VulnerabilityItem struct {
-	ID          string   `json:"id,omitempty"`
-	Package     string   `json:"package,omitempty"`
-	Version     string   `json:"version,omitempty"`
-	FixVersion  string   `json:"fix_version,omitempty"`
-	Severity    Severity `json:"severity,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Links       []string `json:"links,omitempty"`
+	ID               string   `json:"id,omitempty"`
+	Package          string   `json:"package,omitempty"`
+	Version          string   `json:"version,omitempty"`
+	FixVersion       string   `json:"fix_version,omitempty"`
+	Severity         Severity `json:"severity,omitempty"`
+	Description      string   `json:"description,omitempty"`
+	Links            []string `json:"links,omitempty"`
+	CVSS             CVSSData `json:"preferred_cvss"`
+	VendorAttributes CVSS     `json:"vendor_attributes"`
+}
+
+type CVSS struct {
+	CvssKey NVDKey `json:"CVSS"`
+}
+
+type NVDKey struct {
+	NVD CVSSData `json:"Base_Score"`
+}
+
+type CVSSData struct {
+	ScoreV3  float32 `json:"V3Score"`
+	ScoreV2  float32 `json:"V2Score"`
+	VectorV3 string  `json:"V3Vector"`
+	VectorV2 string  `json:"V2Vector"`
 }

--- a/pkg/http/api/v1/handler.go
+++ b/pkg/http/api/v1/handler.go
@@ -115,6 +115,15 @@ func (h *requestHandler) getReport(res http.ResponseWriter, req *http.Request) {
 	}
 
 	res.Header().Set("Content-Type", harbor.ScanReportMimeType)
+	jsonData, err := json.Marshal(vulnerabilityReport)
+	if err != nil {
+		fmt.Println("Error marshalling to JSON:", err)
+		return
+	}
+
+	// Use fmt.Printf to print the JSON string
+	fmt.Printf("%s\n", jsonData)
+
 	_ = json.NewEncoder(res).Encode(vulnerabilityReport)
 }
 

--- a/pkg/scanner/inline_adapter.go
+++ b/pkg/scanner/inline_adapter.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -19,7 +18,7 @@ import (
 	"github.com/sysdiglabs/harbor-scanner-sysdig-secure/pkg/secure"
 )
 
-const jobDefaultTTL = 3600
+const jobDefaultTTL = 86400
 
 var ErrInlineScanError = errors.New("error executing the inline scanner")
 
@@ -54,7 +53,7 @@ type Logger interface {
 
 func NewInlineAdapter(secureClient secure.Client, k8sClient kubernetes.Interface, secureURL, namespace, secret, extraParams string, verifySSL bool, logger Logger) Adapter {
 	return &inlineAdapter{
-		BaseAdapter: BaseAdapter{secureClient: secureClient},
+		BaseAdapter: BaseAdapter{secureClient: secureClient, logger: logger},
 		k8sClient:   k8sClient,
 		secureURL:   secureURL,
 		namespace:   namespace,
@@ -98,11 +97,10 @@ func (i *inlineAdapter) createJobFrom(req harbor.ScanRequest) error {
 
 func (i *inlineAdapter) buildJob(name string, req harbor.ScanRequest) *batchv1.Job {
 	user, password := getUserAndPasswordFrom(req.Registry.Authorization)
-	userPassword := fmt.Sprintf("%s:%s", user, password)
 
 	var envVars = []corev1.EnvVar{
 		{
-			Name: "SYSDIG_API_TOKEN",
+			Name: "SECURE_API_TOKEN", //Renamed for CLI scanner
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
@@ -121,18 +119,28 @@ func (i *inlineAdapter) buildJob(name string, req harbor.ScanRequest) *batchv1.J
 	envVars = appendLocalEnvVar(envVars, "no_proxy")
 	envVars = appendLocalEnvVar(envVars, "NO_PROXY")
 
-	cmdString := fmt.Sprintf("/sysdig-inline-scan.sh --sysdig-url %s -d %s --registry-skip-tls --registry-auth-basic '%s' --format=JSON ", i.secureURL, req.Artifact.Digest, userPassword)
-
-	// Add --sysdig-skip-tls only if insecure
+	//Pass in registry credential variables for CLI scanner to use the robot account that is created for us.
+	envVars = append(envVars, corev1.EnvVar{
+		Name:      "REGISTRY_USER",
+		Value:     user,
+		ValueFrom: nil,
+	}, corev1.EnvVar{
+		Name:      "REGISTRY_PASSWORD",
+		Value:     password,
+		ValueFrom: nil,
+	})
+	envVars = appendLocalEnvVar(envVars, "NO_PROXY")
+	cmdString := fmt.Sprintf("/root/sysdig-cli-scanner -a %s --skiptlsverify --output-json=output.json ", i.secureURL)
+	// Add skiptlsverify if insecure
 	if !i.verifySSL {
-		cmdString += "--sysdig-skip-tls "
+		cmdString += "--skiptlsverify "
 	}
 
 	if i.extraParams != "" {
 		cmdString += fmt.Sprintf("%s ", i.extraParams)
 	}
 
-	cmdString += getImageFrom(req)
+	cmdString += fmt.Sprintf("pull://%s@%s", getImageFrom(req), req.Artifact.Digest)
 	cmdString += "; RC=$?; if [[ $RC -eq 1 ]]; then (exit 0); else (exit $RC); fi"
 	var backoffLimit int32 = 0
 	return &batchv1.Job{
@@ -148,7 +156,7 @@ func (i *inlineAdapter) buildJob(name string, req harbor.ScanRequest) *batchv1.J
 					Containers: []corev1.Container{
 						{
 							Name:    "scanner",
-							Image:   "quay.io/sysdig/secure-inline-scan:2",
+							Image:   "miles3719/sysdig-cli-scanner:0.1", // Using my image but for production we would host it
 							Command: []string{"/bin/sh"},
 							Args: []string{
 								"-c",
@@ -176,8 +184,7 @@ func appendLocalEnvVar(envVars []corev1.EnvVar, key string) []corev1.EnvVar {
 
 func jobName(repository string, shaDigest string) string {
 	return fmt.Sprintf(
-		"inline-scan-%x",
-		md5.Sum([]byte(fmt.Sprintf("%s|%s", repository, shaDigest))))
+		"cli-scanner-%x", md5.Sum([]byte(fmt.Sprintf("%s|%s", repository, shaDigest))))
 }
 
 func (i *inlineAdapter) GetVulnerabilityReport(scanResponseID harbor.ScanRequestID) (harbor.VulnerabilityReport, error) {
@@ -200,12 +207,12 @@ func (i *inlineAdapter) GetVulnerabilityReport(scanResponseID harbor.ScanRequest
 	i.logger.Infof("Scan for %s/%s finished, collecting results from job %s", repository, shaDigest, name)
 	podResults, err := i.collectPodResults(job)
 	if err != nil {
-		i.logger.Errorf("Error collecting inline scanner results for %s/%s:\n%s", repository, shaDigest, err)
+		i.logger.Errorf("Error collecting inline scanner results for %s/%s:%s", repository, shaDigest, err)
 		return harbor.VulnerabilityReport{}, ErrInlineScanError
 	}
 
 	if podResults.ExitCode != 0 && podResults.ExitCode != 1 {
-		i.logger.Errorf("Error executing inline scanner for %s/%s:\n%s", repository, shaDigest, string(podResults.LogBytes))
+		i.logger.Errorf("Error executing inline scanner for %s/%s:%s", repository, shaDigest, string(podResults.LogBytes))
 		return harbor.VulnerabilityReport{}, ErrInlineScanError
 	}
 
@@ -258,7 +265,7 @@ func (i *inlineAdapter) collectPodResults(job *batchv1.Job) (*podResults, error)
 
 	defer podLogs.Close()
 
-	logBytes, err := ioutil.ReadAll(podLogs)
+	logBytes, err := io.ReadAll(podLogs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/secure/client.go
+++ b/pkg/secure/client.go
@@ -6,12 +6,16 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
+	"time"
 )
 
 const (
-	BackendVersion = "3.x"
+	BackendVersion = "SaaS"
 )
 
 var (
@@ -23,7 +27,7 @@ var (
 //go:generate mockgen -source=$GOFILE -destination=./mocks/${GOFILE} -package=mocks
 type Client interface {
 	AddImage(image string, force bool) (ScanResponse, error)
-	GetImage(shaDigest string) (ScanResponse, error)
+	GetImage(shaDigest string) (V2VulnerabilityReport, error)
 
 	GetVulnerabilities(shaDigest string) (VulnerabilityReport, error)
 
@@ -34,6 +38,7 @@ type Client interface {
 	DeleteRegistry(registry string) error
 
 	GetVulnerabilityDescription(vulnerabilityIDs ...string) (map[string]string, error)
+	GetVulnerabilityDescriptionV2(resultId string, VulnId string) (*UrlVuln, error)
 }
 
 func NewClient(apiToken string, secureURL string, verifySSL bool) Client {
@@ -85,31 +90,39 @@ func (s *client) AddImage(image string, force bool) (ScanResponse, error) {
 
 func (s *client) doRequest(method string, url string, payload []byte) (*http.Response, []byte, error) {
 	var emptyBody []byte
+	baseDelay := 1 * time.Second
 
-	request, err := http.NewRequest(
-		method,
-		fmt.Sprintf("%s%s", s.secureURL, url),
-		strings.NewReader(string(payload)))
-	if err != nil {
-		return nil, emptyBody, err
+	for attempt := 0; attempt < 7; attempt++ {
+		request, err := http.NewRequest(method, fmt.Sprintf("%s%s", s.secureURL, url), strings.NewReader(string(payload)))
+		if err != nil {
+			return nil, emptyBody, err
+		}
+
+		request.Header.Add("Content-Type", "application/json")
+		request.Header.Add("Authorization", "Bearer "+s.apiToken)
+
+		response, err := s.client.Do(request)
+		if err != nil {
+			return nil, emptyBody, err
+		}
+
+		body, err := io.ReadAll(response.Body)
+		err = response.Body.Close()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if response.StatusCode != http.StatusTooManyRequests {
+			return response, body, err
+		}
+		fmt.Printf("doRequest:: Got '%d'\n", response.StatusCode)
+		backoff := time.Duration(int64(math.Pow(2, float64(attempt)))) * baseDelay
+
+		time.Sleep(backoff)
+		fmt.Printf("doRequest sleeping for '%d'\n", backoff)
 	}
-
-	request.Header.Add("Content-Type", "application/json")
-	request.Header.Add("Authorization", "Bearer "+s.apiToken)
-
-	response, err := s.client.Do(request)
-	if err != nil {
-		return nil, emptyBody, err
-	}
-
-	body, err := io.ReadAll(response.Body)
-	defer response.Body.Close()
-
-	if err != nil {
-		return nil, emptyBody, err
-	}
-
-	return response, body, nil
+	fmt.Printf("Out of retries, exiting...\n")
+	return nil, emptyBody, fmt.Errorf("too many requests, all retries failed")
 }
 
 func (s *client) checkErrorInSecureAPI(response *http.Response, body []byte) error {
@@ -122,6 +135,21 @@ func (s *client) checkErrorInSecureAPI(response *http.Response, body []byte) err
 		return err
 	}
 	return errors.New(secureError.Message)
+}
+
+type V2VulnerabilityScanResult struct {
+	Page V2PageDetail     `json:"page"`
+	Data []V2ScanDataItem `json:"data"`
+}
+
+type V2PageDetail struct {
+	Total int `json:"total"`
+}
+
+type V2ScanDataItem struct {
+	ResultID                string `json:"resultId"`
+	ImageID                 string `json:"imageId"`
+	PolicyEvaluationsResult string `json:"policyEvaluationsResult"`
 }
 
 type imageScanResultResponse struct {
@@ -137,14 +165,102 @@ type imageScanResult struct {
 	FullTag        string `json:"fullTag"`
 }
 
+type V2VulnerabilityResponse struct {
+	Page V2PageData   `json:"page"`
+	Data []V2DataItem `json:"data"`
+}
+
+type V2PageData struct {
+	Returned int `json:"returned"`
+	Offset   int `json:"offset"`
+	Matched  int `json:"matched"`
+}
+
+type V2DataItem struct {
+	ID             string          `json:"id"`
+	Vuln           V2Vulnerability `json:"vuln"`
+	Package        V2Package       `json:"package"`
+	FixedInVersion string          `json:"fixedInVersion"`
+}
+
+type V2Vulnerability struct {
+	Name           string        `json:"name"`
+	Severity       int           `json:"severity"`
+	CvssVersion    string        `json:"cvssVersion"`
+	CvssScore      float32       `json:"cvssScore"`
+	Exploitable    bool          `json:"exploitable"`
+	Cisakev        bool          `json:"cisakev"`
+	DisclosureDate time.Time     `json:"disclosureDate"`
+	AcceptedRisks  []interface{} `json:"acceptedRisks"` // Use []interface{} if the risks vary in type or are unknown.
+}
+
+type V2Package struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Type    string `json:"type"`
+	Running bool   `json:"running"`
+}
+
+func (s *client) retrieveFullVulnerabilityReport(resultID string) (*V2VulnerabilityResponse, error) {
+	var result V2VulnerabilityResponse
+	var partialResult V2VulnerabilityResponse
+
+	offset := 0
+	limit := 100
+	baseUrl := fmt.Sprintf("/api/scanning/scanresults/v2/results/%s/vulnPkgs", resultID)
+	queryParams := url.Values{}
+	queryParams.Set("limit", strconv.Itoa(limit))
+	queryParams.Set("order", "asc")
+	queryParams.Set("sort", "vulnSeverity")
+
+	var allData []V2DataItem
+	for {
+		queryParams.Set("offset", strconv.Itoa(offset))
+		fullUrl := fmt.Sprintf("%s?%s", baseUrl, queryParams.Encode())
+		response, body, err := s.doRequest(http.MethodGet, fullUrl, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := s.checkErrorInSecureAPI(response, body); err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(body, &partialResult); err != nil {
+			return nil, err
+		}
+
+		allData = append(allData, partialResult.Data...)
+		if partialResult.Page.Returned < limit {
+			break
+		}
+
+		offset += limit
+	}
+
+	result.Data = allData
+	return &result, nil
+}
+
 func (s *client) GetVulnerabilities(shaDigest string) (VulnerabilityReport, error) {
-	var checkScanResultResponse imageScanResultResponse
+	//var checkScanResultResponse imageScanResultResponse
+	var checkScanResultResponse V2VulnerabilityScanResult
+
 	var result VulnerabilityReport
+
+	baseUrl := "/secure/vulnerability/v1beta1/pipeline-results"
+	queryParams := url.Values{}
+	queryParams.Set("filter", fmt.Sprintf("freeText in (\"%s\")", shaDigest))
+	queryParams.Set("limit", "1")
+
+	fullUrl := fmt.Sprintf("%s?%s", baseUrl, queryParams.Encode())
 
 	response, body, err := s.doRequest(
 		http.MethodGet,
-		fmt.Sprintf("/api/scanning/v1/results?filter=%s&limit=%d", shaDigest, 1),
-		nil)
+		//fmt.Sprintf("/api/scanning/v1/results?filter=%s&limit=%d", shaDigest, 1),
+		fullUrl, nil)
+
 	if err != nil {
 		return result, err
 	}
@@ -156,25 +272,76 @@ func (s *client) GetVulnerabilities(shaDigest string) (VulnerabilityReport, erro
 		return result, err
 	}
 
-	if len(checkScanResultResponse.Results) == 0 {
+	statusMap := map[string]bool{
+		"passed": true,
+		"failed": true,
+	}
+
+	if checkScanResultResponse.Page.Total == 0 {
 		return result, ErrImageNotFound
-	} else if img := checkScanResultResponse.Results[0]; img.AnalysisStatus != "analyzed" {
+	} else if _, img := statusMap[checkScanResultResponse.Data[0].PolicyEvaluationsResult]; !img {
 		return result, ErrVulnerabilityReportNotReady
 	}
 
-	response, body, err = s.doRequest(
-		http.MethodGet,
-		fmt.Sprintf("/api/scanning/v1/images/%s/vulnDirect/all?includeVulnExceptions=%t", shaDigest, false),
-		nil)
-	if err != nil {
-		return result, err
+	resultId := checkScanResultResponse.Data[0].ResultID
+
+	V2VulnResponse, err := s.retrieveFullVulnerabilityReport(resultId)
+	// Convert data into the v1 legacy format as best as possible
+	result = VulnerabilityReport{
+		ImageDigest:       checkScanResultResponse.Data[0].ImageID,
+		VulnerabilityType: "all",
+		Vulnerabilities:   []*Vulnerability{},
+	}
+	severityMap := map[int]string{
+		2: "Critical",
+		3: "High",
+		5: "Medium",
+		6: "Low",
+		7: "Negligible",
 	}
 
-	if err = s.checkErrorInSecureAPI(response, body); err != nil {
-		return result, err
-	}
-	if err = json.Unmarshal(body, &result); err != nil {
-		return result, err
+	for _, row := range V2VulnResponse.Data {
+		var cvssV2ValueFloat float32
+		var cvssV3ValueFloat float32
+		if strings.HasPrefix(row.Vuln.CvssVersion, "3") {
+			cvssV3ValueFloat = row.Vuln.CvssScore
+		} else if strings.HasPrefix(row.Vuln.CvssVersion, "2") {
+			cvssV2ValueFloat = row.Vuln.CvssScore
+		}
+		cvssV3 := CVSS{
+			BaseScore:           cvssV3ValueFloat,
+			ExploitabilityScore: 0,
+			ImpactScore:         0,
+		}
+		cvssV2 := CVSS{
+			BaseScore:           cvssV2ValueFloat,
+			ExploitabilityScore: 0,
+			ImpactScore:         0,
+		}
+		nvd := NVDData{
+			ID:     row.Vuln.Name,
+			CVSSV2: &cvssV2,
+			CVSSV3: &cvssV3,
+		}
+
+		vuln := Vulnerability{
+			Feed:           "vulnerabilities",
+			FeedGroup:      "",
+			Fix:            row.FixedInVersion,
+			NVDData:        []*NVDData{&nvd},
+			Package:        fmt.Sprintf("%s-%s", row.Package.Name, row.Package.Version),
+			PackageCPE:     "None",
+			PackageName:    row.Package.Name,
+			PackagePath:    "",
+			PackageType:    row.Package.Type,
+			PackageVersion: row.Package.Version,
+			ResultId:       resultId,
+			Severity:       severityMap[row.Vuln.Severity],
+			URL:            "",
+			Vuln:           row.Vuln.Name,
+			VulnId:         row.ID,
+		}
+		result.Vulnerabilities = append(result.Vulnerabilities, &vuln)
 	}
 
 	return result, nil
@@ -255,17 +422,41 @@ func (s *client) DeleteRegistry(registry string) error {
 	return nil
 }
 
-func (s *client) GetImage(shaDigest string) (ScanResponse, error) {
-	var emptyResult ScanResponse
+type V2PageDetails struct {
+	Returned int    `json:"returned"`
+	Matched  int    `json:"matched"`
+	Next     string `json:"next"`
+}
 
-	response, body, err := s.doRequest(
-		http.MethodGet,
-		fmt.Sprintf("/api/scanning/v1/anchore/images/%s", shaDigest),
-		nil)
+type V2VulnerabilityData struct {
+	ID                      string    `json:"id"`
+	StoredAt                time.Time `json:"storedAt"`
+	ImageID                 string    `json:"imageId"`
+	ImagePullString         string    `json:"imagePullString"`
+	VulnsBySev              []int     `json:"vulnsBySev"`
+	ExploitCount            int       `json:"exploitCount"`
+	PolicyEvaluationsResult string    `json:"policyEvaluationsResult"`
+	HasAcceptedRisk         bool      `json:"hasAcceptedRisk"`
+}
+
+type V2VulnerabilityReport struct {
+	Page V2PageDetails         `json:"page"`
+	Data []V2VulnerabilityData `json:"data"`
+}
+
+func (s *client) GetImage(shaDigest string) (V2VulnerabilityReport, error) {
+	var emptyResult V2VulnerabilityReport
+
+	baseUrl := "/api/scanning/scanresults/v2/results"
+	queryParams := url.Values{}
+	queryParams.Set("limit", "1")
+	queryParams.Set("filter", fmt.Sprintf("freeText in (\"%s\")", shaDigest))
+	fullUrl := fmt.Sprintf("%s?%s", baseUrl, queryParams.Encode())
+
+	response, body, err := s.doRequest(http.MethodGet, fullUrl, nil)
 	if err != nil {
 		return emptyResult, err
 	}
-
 	if err = s.checkErrorInSecureAPI(response, body); err != nil {
 		if err.Error() == "image not found in DB" {
 			return emptyResult, ErrImageNotFound
@@ -273,12 +464,12 @@ func (s *client) GetImage(shaDigest string) (ScanResponse, error) {
 		return emptyResult, err
 	}
 
-	var result []ScanResponse
+	var result V2VulnerabilityReport
 	if err = json.Unmarshal(body, &result); err != nil {
 		return emptyResult, err
 	}
 
-	return result[0], nil
+	return result, nil
 }
 
 func (s *client) GetFeeds() ([]Feed, error) {
@@ -310,6 +501,54 @@ type vulnerabilityDescription struct {
 
 type vulnerabilityResponse struct {
 	Vulnerabilities []vulnerabilityDescription `json:"vulnerabilities"`
+}
+
+type VulnerabilityDetail struct {
+	Vuln VulnDetail `json:"vuln"`
+}
+
+type VulnDetail struct {
+	CvssScore   CvssScoreDetail `json:"cvssScore"`
+	Description string          `json:"description"`
+}
+
+type CvssScoreDetail struct {
+	Reporter URLDetail `json:"reporter"`
+}
+
+type URLDetail struct {
+	URL string `json:"url"`
+}
+
+type UrlVuln struct {
+	URL         string
+	Description string
+}
+
+func (s *client) GetVulnerabilityDescriptionV2(resultId string, VulnId string) (*UrlVuln, error) {
+	result := UrlVuln{}
+
+	response, body, err := s.doRequest(
+		http.MethodGet,
+		fmt.Sprintf("/api/scanning/scanresults/v2/results/%s/vulnPkgs/%s", resultId, VulnId),
+		nil)
+	if err != nil {
+		return &result, err
+	}
+
+	if err = s.checkErrorInSecureAPI(response, body); err != nil {
+		return &result, err
+	}
+
+	var res VulnerabilityDetail
+	if err = json.Unmarshal(body, &res); err != nil {
+		return &result, err
+	}
+
+	result.Description = res.Vuln.Description
+	result.URL = res.Vuln.CvssScore.Reporter.URL
+
+	return &result, nil
 }
 
 func (s *client) GetVulnerabilityDescription(vulnerabilitiesIDs ...string) (map[string]string, error) {

--- a/pkg/secure/mocks/client.go
+++ b/pkg/secure/mocks/client.go
@@ -123,7 +123,7 @@ func (mr *MockClientMockRecorder) GetVulnerabilities(shaDigest interface{}) *gom
 }
 
 // GetVulnerabilityDescription mocks base method.
-func (m *MockClient) GetVulnerabilityDescription(vulnerabilityIDs ...string) (map[string]string, error) {
+func (m *MockClient) GetVulnerabilityDescription(resultId string, vulnerabilityIDs ...string) (map[string]string, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range vulnerabilityIDs {

--- a/pkg/secure/model.go
+++ b/pkg/secure/model.go
@@ -66,9 +66,11 @@ type Vulnerability struct {
 	PackagePath    string     `json:"package_path"`
 	PackageType    string     `json:"package_type"`
 	PackageVersion string     `json:"package_version"`
+	ResultId       string     // Not serialised (Notice the S not Z, we use 'proper' english :)
 	Severity       string     `json:"severity"`
 	URL            string     `json:"url"`
 	Vuln           string     `json:"vuln"`
+	VulnId         string     // Not serialised either, used for description querying
 }
 
 type NVDData struct {


### PR DESCRIPTION
Initial PR for CLI v2 scanner functionality.

The main pain points here are the use of V2 api's due to the way that the `v1beta` apis do not carry the description and URL which we need (or if we don't we can cut it out... but its good to have them imho)

The methodology that I have taken is to try and be as respectful to the current logic as much as possible.  So some things are a little longer than they would be had we have re-written everything from scratch.  So for example rather than creating a new `VulnerabilityItem` construct for V2, it simply pulls the data from the V2 endpoints then transposes them into the v1 construct.  This aides in allowing the logic to flow through the various other functions unchanged.

Points of Note that still need to be considered

* API's used are v2 api's as the current v1beta APIs for v2 functionality do not have (so far as I could tell) an API that would let you link together a scan result with an API that would let you query the description for a vulnerability like the v1 anchore API's do

* Descriptions are pulled from vulnPkgs endpoint.  Sadly I have not found an API that allows us to get more than one description at once (i.e more than one image).  This means that we hit up against the APi rate limit

* To the point of API rate limiting, I have modified the `doRequest` function to handle `429 - Too many requests` and some rudimentary backoff functionality is implemented.  Ideally we need to either 1) find a better API that gives all the descriptions and URLs we need OR have somewhere in the README that tells people to contact sysdig support to have their rate limit upgraded from 50 to xxx ?

* Vuln URLS come from the same description endpoint as could not find it in v1beta APi's. 

* Logging has been extended retrospectively into the base adapter and logging of payloads is present in Debug mode.

* The API payload spec has been moved to `1.1`, i.e `"application/vnd.security.vulnerability.report; version=1.1`. This allows us to present CVSS data into the report which was not present in `1.0`

* APi spec as provided by Harbor is not correct.  I had to scrape one from the trivvy scanner to see how to make it work (using vendor attributes

* Updates vendor tag from `Sysdig 3.x` to `Sysdig SaaS`.

* Readme has been updated to replace `inline` scanning to `CLI` scanning

* Command line parameter for scanning has changed from `--inline_scanning` to `--cli_scanning`

* Pod spec has changed to use a container that implements the CLI scanner.  Currently just using a version that I wrote, but we will need to change this to sysdig hosted one.  Dockerfile is below
```
FROM ubuntu:22.04@sha256:6d7b5d3317a71adb5e175640150e44b8b9a9401a7dd394f44840626aff9fa94d

RUN apt-get update && apt-get -y install curl

WORKDIR /root
RUN curl -LO "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/$(curl -L -s https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)/linux/amd64/sysdig-cli-scanner"
RUN chmod +x sysdig-cli-scanner
```

* CVSS Datai is now present with the 'tag' being `Base_Score`.  This looks pretty good in the UI and is how other scanners present the data.

* Updated artifact tag stanza with image data from V2.  Some transposing is needed so I have split it up into segments. Means more lines of code, but easier to read imho.

* Implemented `REGISTRY_USER` and `REGISTRY_PASSWORD` functionality that is (quietly) part of the CLI scanner to handle the robot account that is created for each scan so you can pull the image

* 
 