### PR TITLE
release: v0.8.5

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,7 +1,7 @@
 { buildGoModule }:
 buildGoModule {
   pname = "harbor-scanner-sysdig-secure";
-  version = "0.8.4";
+  version = "0.8.5";
   vendorHash = "sha256-fytzhgoLL2OA4eK7HOyIbFmdhE/E6ceiYuynGLJT3gQ=";
   src = ./.;
   subPackages = [


### PR DESCRIPTION
## Release v0.8.5

Bumps `package.nix` version 0.8.4 → 0.8.5. **Merging this to master triggers the release workflow** — Docker image push to DockerHub (`sysdiglabs/harbor-scanner-sysdig-secure:0.8.5` + `:latest`), git tag `v0.8.5`, and a GitHub release with generated changelog.

## Changes since v0.8.4
- **fix(scanner):** handle digest-only `MainAssetName` without panic — prevents a runtime crash in report generation and correctly populates the Harbor artifact for un-prefixed repositories (#44, thanks @henrikfrech 🙌)
- **chore(deps):** dependency refresh — `golang.org/x/net` → 0.57.0 (fixes 4 HIGH CVEs), k8s libraries → 0.36.2, ginkgo/gomega bumps; pinned `harbor-cli` and fixed the e2e skopeo v2 registries.conf issue for CI stability (#45)

## Notes
- No functional/API changes to the adapter beyond the panic fix — patch release.
- vendorHash unchanged (version-only bump).